### PR TITLE
fix(metadata): Remove Duplicate Site Names from Page Titles

### DIFF
--- a/src/app/(public)/events/calendar/page.tsx
+++ b/src/app/(public)/events/calendar/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Calendar, ExternalLink } from "lucide-react";
 
 import { siteConfig } from "@/config/site";
-import { createPageMetadata } from "@/lib/metadata";
+import { createPageMetadata, pageDescriptions } from "@/lib/metadata";
 import { Button } from "@/components/ui/button";
 
 // ============================================================================
@@ -11,8 +11,7 @@ import { Button } from "@/components/ui/button";
 
 export const metadata: Metadata = createPageMetadata({
   title: "Events Calendar",
-  description:
-    "Upcoming events, seminars, and meetings at the Materials and Process Simulation Center.",
+  description: pageDescriptions.calendar,
   path: "/events/calendar",
 });
 

--- a/src/app/(public)/events/photos/page.tsx
+++ b/src/app/(public)/events/photos/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Camera, Calendar as CalendarIcon } from "lucide-react";
 
 import { getPhotosGroupedByYear, getPhotoStats } from "@/lib/db/queries/photos";
-import { createPageMetadata } from "@/lib/metadata";
+import { createPageMetadata, pageDescriptions } from "@/lib/metadata";
 import { PhotoGallery } from "@/components/events";
 
 // ============================================================================
@@ -11,8 +11,7 @@ import { PhotoGallery } from "@/components/events";
 
 export const metadata: Metadata = createPageMetadata({
   title: "Group Photos",
-  description:
-    "Photo gallery of the Materials and Process Simulation Center team through the years.",
+  description: pageDescriptions.photos,
   path: "/events/photos",
 });
 

--- a/src/app/admin/(authenticated)/admins/page.tsx
+++ b/src/app/admin/(authenticated)/admins/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import type { Metadata } from "next";
 
 import { PageHeader } from "@/components/admin/layout";
 import { AdminListSkeleton } from "@/components/admin/shared";
@@ -10,8 +11,8 @@ import { AdminList, AccountView } from "./_components";
 // Metadata
 // ============================================================================
 
-export const metadata = {
-  title: "Administrators | Admin",
+export const metadata: Metadata = {
+  title: "Administrators",
   description: "Manage administrator accounts and roles",
 };
 

--- a/src/app/admin/(authenticated)/collaborators/page.tsx
+++ b/src/app/admin/(authenticated)/collaborators/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import type { Metadata } from "next";
 
 import { PageHeader } from "@/components/admin/layout";
 import { CollaboratorListSkeleton } from "@/components/admin/shared";
@@ -9,8 +10,8 @@ import { CollaboratorList } from "./_components";
 // Metadata
 // ============================================================================
 
-export const metadata = {
-  title: "Collaborators | Admin",
+export const metadata: Metadata = {
+  title: "Collaborators",
   description: "Manage collaborators and their locations",
 };
 

--- a/src/app/admin/(authenticated)/layout.tsx
+++ b/src/app/admin/(authenticated)/layout.tsx
@@ -1,7 +1,21 @@
 import { redirect } from "next/navigation";
+import type { Metadata } from "next";
 
 import { getCurrentUser } from "@/lib/auth";
+import { siteConfig } from "@/config/site";
 import { Sidebar, TopBar, AuthKeepAlive } from "@/components/admin/layout";
+
+// ============================================================================
+// Metadata
+// ============================================================================
+
+export const metadata: Metadata = {
+  title: {
+    template: `%s | Admin | ${siteConfig.name}`,
+    default: `Admin | ${siteConfig.name}`,
+  },
+  robots: "noindex,nofollow",
+};
 
 // ============================================================================
 // Route Config

--- a/src/app/admin/(authenticated)/members/categories/page.tsx
+++ b/src/app/admin/(authenticated)/members/categories/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import type { Metadata } from "next";
 
 import { PageHeader } from "@/components/admin/layout";
 import { ListSkeleton } from "@/components/admin/shared";
@@ -9,8 +10,8 @@ import { CategoryList } from "./_components";
 // Metadata
 // ============================================================================
 
-export const metadata = {
-  title: "Member Categories | Admin",
+export const metadata: Metadata = {
+  title: "Member Categories",
   description: "Manage member categories and display order",
 };
 

--- a/src/app/admin/(authenticated)/members/page.tsx
+++ b/src/app/admin/(authenticated)/members/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import Link from "next/link";
+import type { Metadata } from "next";
 import { Settings } from "lucide-react";
 
 import { PageHeader } from "@/components/admin/layout";
@@ -12,8 +13,8 @@ import { MemberList } from "./_components";
 // Metadata
 // ============================================================================
 
-export const metadata = {
-  title: "Members | Admin",
+export const metadata: Metadata = {
+  title: "Members",
   description: "Manage team members and their profiles",
 };
 

--- a/src/app/admin/(authenticated)/page.tsx
+++ b/src/app/admin/(authenticated)/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from "next";
+
 import { getDashboardStats } from "@/lib/admin/actions";
 import { PublicationChart, RecentActivity, StatsGrid } from "./_components";
 
@@ -5,8 +7,8 @@ import { PublicationChart, RecentActivity, StatsGrid } from "./_components";
 // Metadata
 // ============================================================================
 
-export const metadata = {
-  title: "Dashboard | Admin",
+export const metadata: Metadata = {
+  title: "Dashboard",
   description: "Overview of your site content and activity",
 };
 

--- a/src/app/admin/(authenticated)/photos/page.tsx
+++ b/src/app/admin/(authenticated)/photos/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import type { Metadata } from "next";
 
 import { PageHeader } from "@/components/admin/layout";
 import { PhotoGridSkeleton } from "@/components/admin/shared";
@@ -9,8 +10,8 @@ import { PhotoList } from "./_components";
 // Metadata
 // ============================================================================
 
-export const metadata = {
-  title: "Group Photos | Admin",
+export const metadata: Metadata = {
+  title: "Group Photos",
   description: "Manage group photos and display order",
 };
 

--- a/src/app/admin/(authenticated)/publications/page.tsx
+++ b/src/app/admin/(authenticated)/publications/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import type { Metadata } from "next";
 
 import { PageHeader } from "@/components/admin/layout";
 import { PublicationListSkeleton } from "@/components/admin/shared";
@@ -13,8 +14,8 @@ import { PublicationList } from "./_components";
 // Metadata
 // ============================================================================
 
-export const metadata = {
-  title: "Publications | Admin",
+export const metadata: Metadata = {
+  title: "Publications",
   description: "Manage research publications",
 };
 

--- a/src/app/admin/(authenticated)/research/page.tsx
+++ b/src/app/admin/(authenticated)/research/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import type { Metadata } from "next";
 
 import { PageHeader } from "@/components/admin/layout";
 import { ResearchTreeSkeleton } from "@/components/admin/shared";
@@ -9,8 +10,8 @@ import { ResearchList } from "./_components";
 // Metadata
 // ============================================================================
 
-export const metadata = {
-  title: "Research Areas | Admin",
+export const metadata: Metadata = {
+  title: "Research Areas",
   description: "Manage research areas and their hierarchy",
 };
 

--- a/src/app/admin/(authenticated)/sync/page.tsx
+++ b/src/app/admin/(authenticated)/sync/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from "next";
+
 import { getSyncStats } from "@/lib/admin/actions";
 import { PageHeader } from "@/components/admin/layout";
 import { SyncDashboard } from "./_components";
@@ -6,8 +8,8 @@ import { SyncDashboard } from "./_components";
 // Metadata
 // ============================================================================
 
-export const metadata = {
-  title: "Data Sync | Admin",
+export const metadata: Metadata = {
+  title: "Data Sync",
   description: "Sync publication metadata and rebuild data relationships",
 };
 

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -77,19 +77,3 @@ export const mainNav: NavItem[] = [
     ],
   },
 ] as const;
-
-// ============================================================================
-// SEO Defaults
-// ============================================================================
-
-export const seoDefaults = {
-  defaultTitle: `${siteConfig.name} - ${siteConfig.fullName}`,
-  openGraph: {
-    type: "website",
-    locale: "en_US",
-    siteName: siteConfig.name,
-  },
-  twitter: {
-    card: "summary_large_image",
-  },
-} as const;

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -32,24 +32,33 @@ export function createPageMetadata({
   noIndex = false,
 }: PageMetadataOptions = {}): Metadata {
   const ogTitle = title ? `${title} | ${siteConfig.name}` : undefined;
-
   const url = path !== undefined ? `${siteConfig.url}${path}` : undefined;
+  const hasContent = !!(ogTitle || description);
+  const resolvedImage = image ?? siteConfig.images.ogImage;
 
   return {
     ...(title && { title }),
     ...(description && { description }),
     ...(noIndex && { robots: "noindex,nofollow" }),
-    openGraph: {
-      ...(ogTitle && { title: ogTitle }),
-      ...(description && { description }),
-      ...(url && { url }),
-      ...(image && { images: [{ url: image }] }),
-    },
-    twitter: {
-      ...(ogTitle && { title: ogTitle }),
-      ...(description && { description }),
-      ...(image && { images: [image] }),
-    },
+    ...(hasContent && {
+      openGraph: {
+        type: "website",
+        locale: "en_US",
+        siteName: siteConfig.name,
+        ...(ogTitle && { title: ogTitle }),
+        ...(description && { description }),
+        ...(url && { url }),
+        images: [{ url: resolvedImage }],
+      },
+    }),
+    ...(hasContent && {
+      twitter: {
+        card: "summary_large_image",
+        ...(ogTitle && { title: ogTitle }),
+        ...(description && { description }),
+        images: [resolvedImage],
+      },
+    }),
     ...(url && { alternates: { canonical: url } }),
   };
 }

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -5,7 +5,7 @@
  */
 
 import type { Metadata } from "next";
-import { siteConfig, seoDefaults } from "@/config/site";
+import { siteConfig } from "@/config/site";
 import { truncateAtWordBoundary } from "@/lib/format";
 import { getYear } from "@/lib/date";
 
@@ -24,43 +24,33 @@ interface PageMetadataOptions {
 /**
  * Generate metadata for a page.
  */
-export function createPageMetadata(
-  options: PageMetadataOptions = {}
-): Metadata {
-  const {
-    title,
-    description = siteConfig.description,
-    path = "",
-    image = siteConfig.images.ogImage,
-    noIndex = false,
-  } = options;
+export function createPageMetadata({
+  title,
+  description,
+  path,
+  image,
+  noIndex = false,
+}: PageMetadataOptions = {}): Metadata {
+  const ogTitle = title ? `${title} | ${siteConfig.name}` : undefined;
 
-  const fullTitle = title
-    ? `${title} | ${siteConfig.name}`
-    : seoDefaults.defaultTitle;
-
-  const url = `${siteConfig.url}${path}`;
+  const url = path !== undefined ? `${siteConfig.url}${path}` : undefined;
 
   return {
-    title: fullTitle,
-    description,
+    ...(title && { title }),
+    ...(description && { description }),
     ...(noIndex && { robots: "noindex,nofollow" }),
     openGraph: {
-      ...seoDefaults.openGraph,
-      title: fullTitle,
-      description,
-      url,
-      images: image ? [{ url: image }] : undefined,
+      ...(ogTitle && { title: ogTitle }),
+      ...(description && { description }),
+      ...(url && { url }),
+      ...(image && { images: [{ url: image }] }),
     },
     twitter: {
-      ...seoDefaults.twitter,
-      title: fullTitle,
-      description,
-      images: image ? [image] : undefined,
+      ...(ogTitle && { title: ogTitle }),
+      ...(description && { description }),
+      ...(image && { images: [image] }),
     },
-    alternates: {
-      canonical: url,
-    },
+    ...(url && { alternates: { canonical: url } }),
   };
 }
 
@@ -74,16 +64,15 @@ export function createMemberMetadata(member: {
   bio?: string | null;
   photo?: string | null;
 }): Metadata {
-  const title = member.name;
   const description = member.bio
     ? truncateAtWordBoundary(member.bio, 160)
     : `${member.name}${member.position ? ` - ${member.position}` : ""} at ${siteConfig.fullName}, Caltech.`;
 
   return createPageMetadata({
-    title,
+    title: member.name,
     description,
     path: `/members/${member.id}`,
-    image: member.photo || siteConfig.images.ogImage,
+    ...(member.photo && { image: member.photo }),
   });
 }
 
@@ -155,6 +144,8 @@ export const pageDescriptions = {
   research: `Explore research areas at ${siteConfig.fullName}, Caltech.`,
   collaborators: `Global research partners and collaborators of ${siteConfig.fullName}.`,
   events: `Events, group photos, and calendar for ${siteConfig.fullName}.`,
+  photos: `Photo gallery of ${siteConfig.fullName} team through the years.`,
+  calendar: `Upcoming events, seminars, and meetings at ${siteConfig.fullName}.`,
   wag: `Prof. William A. Goddard III, Director of ${siteConfig.fullName} at Caltech.`,
   msc: `About ${siteConfig.fullName} at the California Institute of Technology.`,
 } as const;


### PR DESCRIPTION
### Summary:

Corrected an issue where page titles were displaying duplicate site names (e.g., "Research | Caltech MSC | Caltech MSC") by refactoring the metadata generation utility. This change ensures clean, SEO-friendly titles by delegating the title template formatting to the root layout, rather than manually appending the site name in every page's metadata function.

### Changes:

- **Refactored `createPageMetadata` (`src/lib/metadata.ts`):**
  - Removed manual site name concatenation in favor of returning clean title strings.
  - Updated to construct OpenGraph and Twitter metadata objects conditionally, avoiding redundant title suffixes.
  - Simplified the function signature to accept destructured options directly.

- **Centralized Title Template (`src/app/layout.tsx`):**
  - Moved the title template configuration (`%s | Caltech MSC`) to the root layout metadata export.
  - Defined a default title (`Caltech MSC`) for the root page.

- **Updated Page Metadata:**
  - Removed manual title formatting from Admin pages (`admins`, `collaborators`, `members`, `photos`, `publications`, `research`, `sync`).
  - Updated public pages (`calendar`, `photos`) to use `pageDescriptions` constants for consistency.
  - Ensured specific entity pages (Member Detail, Publication Detail) pass raw titles (e.g., Member Name) to leverage the new template system.

- **Cleaned Up Configuration:**
  - Removed `seoDefaults` from `src/config/site.ts` as its logic is now handled more robustly within `metadata.ts` and `layout.tsx`.